### PR TITLE
add "react-native-linear-gradient" to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "url": "https://github.com/jobtoday/react-native-image-viewing/issues"
   },
   "homepage": "https://github.com/sepakk/react-native-image-viewing#readme",
+  "dependencies": {
+    "react-native-linear-gradient": "^2.5.6"
+  },
   "devDependencies": {
     "@babel/runtime": "7.7.4",
     "@types/react": "16.9.13",
@@ -42,7 +45,6 @@
     "react": "16.12.0",
     "react-native": "0.61.5",
     "typescript": "3.7.2",
-    "react-native-vector-icons": "6.6.0",
-    "react-native-linear-gradient": "^2.5.6"
+    "react-native-vector-icons": "6.6.0"
   }
 }


### PR DESCRIPTION
add "react-native-linear-gradient" to dependencies - it was in devDependencies and was causing errors because it wouldn't get installed when this project was installed.